### PR TITLE
Add planning notes for packaging

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -2,3 +2,5 @@
 - 2025-07-22 22:12 UTC: Created initial design notes under `design/` and populated `TASKS.md` with three starter tasks for securing API keys, adding tests, and introducing a configuration module.
 - 2025-07-22 22:35 UTC: Added architecture overview document and expanded TASKS.md with modularization tasks.
 - 2025-07-22 23:05 UTC: Documented next steps in `design/plan-2025-07-23.md` and extended task list with logging and CI tasks.
+
+- 2025-07-22 23:39 UTC: Added plan-2025-07-24.md with packaging objectives and outlined incremental extraction steps.

--- a/TASKS.md
+++ b/TASKS.md
@@ -6,6 +6,8 @@
 - [T4] Modularize project into `collector/` package · Acceptance: create `collector/api.py`, `collector/db.py`, `collector/cli.py`, `collector/stream.py`, and update main script to import these modules · Assignee: Coder
 - [T6] Add logging module · Acceptance: logs written to a user-specified file with configurable level; CLI flag `--log-file` available · Assignee: Coder
 - [T7] Setup CI workflow · Acceptance: `.github/workflows/ci.yml` runs `black --check` and `pytest -q` on push · Assignee: Tester
+- [T8] Package project for distribution · Acceptance: `pyproject.toml` defines `collector` package and entry point; `pip install -e .` works · Assignee: Coder
+- [T9] Document environment variables · Acceptance: README explains `POLYGON_API_KEY` and logging config section · Assignee: Reviewer
 
 # Completed Tasks
 

--- a/design/plan-2025-07-24.md
+++ b/design/plan-2025-07-24.md
@@ -1,0 +1,13 @@
+# Planning Notes - 2025-07-24
+
+## Objectives
+- Kick off implementation of existing tasks starting with API key security and modularization.
+- Introduce packaging metadata so the collector can be installed as a CLI tool.
+
+## Proposed Tasks
+1. Add `pyproject.toml` with basic project metadata and entry point for `collector.main`.
+2. Document environment variable configuration for `POLYGON_API_KEY` and logging path.
+3. Plan incremental extraction of functions into the `collector` package.
+4. Ensure tests and CI run for every module as it is created.
+
+These notes set the direction for the next development cycle.


### PR DESCRIPTION
## Summary
- add planning doc for July 24 with packaging and extraction goals
- expand `TASKS.md` with packaging and env docs
- log planner update in `NOTES.md`

## Testing
- `black . --check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688020e865688324bc199f9272655638