### PR TITLE
Add planning notes and new tasks

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,4 +1,5 @@
 # Planner
+- 2025-07-23 00:34 UTC: Planned caching, news collection and WebSocket tests; see plan-2025-07-26.md and updated TASKS.md.
 - 2025-07-22 22:12 UTC: Created initial design notes under `design/` and populated `TASKS.md` with three starter tasks for securing API keys, adding tests, and introducing a configuration module.
 - 2025-07-22 22:35 UTC: Added architecture overview document and expanded TASKS.md with modularization tasks.
 - 2025-07-22 23:05 UTC: Documented next steps in `design/plan-2025-07-23.md` and extended task list with logging and CI tasks.

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,9 @@
 # Open Tasks
 
 - [T9] Document environment variables · Acceptance: README explains `POLYGON_API_KEY` and logging config section · Assignee: Reviewer
+- [T10] Add WebSocket tests for stream_quotes · Acceptance: mocked server verifies reconnect logic; `pytest -q` passes · Assignee: Tester
+- [T11] Implement HTTP caching layer · Acceptance: repeated API calls within TTL skip network request; TTL set via `CACHE_TTL` env var; tests updated · Assignee: Coder
+- [T12] Integrate NewsAPI for headlines · Acceptance: `collector.api` stores top articles in `news` table; schema documented · Assignee: DataCollector
 
 # Completed Tasks
 

--- a/design/plan-2025-07-26.md
+++ b/design/plan-2025-07-26.md
@@ -1,0 +1,19 @@
+# Planning Notes - 2025-07-26
+
+## Status
+The collector package now supports argument parsing, logging and a CI workflow. Basic
+fetch functions are covered by unit tests. Documentation still lacks a dedicated
+section describing environment variables.
+
+## Next Goals
+1. **Environment Variable Docs** – Expand `README.md` with a section detailing
+   `POLYGON_API_KEY` usage and examples for log configuration.
+2. **WebSocket Tests** – Create tests for `stream.stream_quotes` using a mocked
+   WebSocket server to ensure reconnect behaviour when real-time feed is
+   unauthorized.
+3. **HTTP Caching** – Implement a simple caching layer for `rate_limited_get`
+   to avoid repeated requests during the same run. Configurable TTL via env var.
+4. **News Data Collection** – Extend `collector.api` to fetch recent news via
+   NewsAPI and store results under `news` table. Document schema in `db.py`.
+
+These objectives will feed into feature engineering and playbook generation.


### PR DESCRIPTION
## Summary
- add design notes for next planning cycle
- list new tasks including caching, news data and websocket tests
- record planning note in NOTEs

## Testing
- `black . --check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68802d6fdb408324a31abe68da979718