### PR TITLE
Add design for connectivity test command

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -3,6 +3,7 @@
 - 2025-07-31 00:15 UTC: Reviewed repository status; created plan-2025-07-31.md with new tasks T18-T20 and moved T15 to completed.
 - 2025-08-01 00:10 UTC: Created plan-2025-08-01.md with tasks T21-T25 added to open list.
 - 2025-08-02 00:15 UTC: Reviewed modeling updates; added plan-2025-08-02.md and task T26 for Reviewer.
+- 2025-08-03 00:10 UTC: Planned connectivity test command and wrote plan-2025-08-03.md; added tasks T27 and T28.
 - 2025-07-28 00:10 UTC: Planned news integration and playbook generation; see plan-2025-07-28.md and new tasks T16-T17.
 - 2025-07-27 00:45 UTC: Planned feature engineering and modeling tasks; see plan-2025-07-27.md and new tasks T13-T15.
 - 2025-07-23 00:34 UTC: Planned caching, news collection and WebSocket tests; see plan-2025-07-26.md and updated TASKS.md.

--- a/TASKS.md
+++ b/TASKS.md
@@ -7,6 +7,8 @@
 - [T23] Historical data backfill script · Acceptance: `collector.backfill` downloads missing bars for a date range; unit test validates row count · Assignee: DataCollector
 - [T25] Docker packaging · Acceptance: `Dockerfile` and `run_pipeline.sh` enable one-command execution; instructions in README · Assignee: Coder
 - [T26] Review modeling updates · Acceptance: confirm docs and tests for new features, run `pytest -q` and squash-merge · Assignee: Reviewer
+- [T27] Connectivity test command · Acceptance: `collector.verify` fetches OHLCV and option data for up to 5 symbols using API keys provided via CLI and prints a summary; README documents usage · Assignee: DataCollector
+- [T28] Tests for connectivity command · Acceptance: pytest covers success and failure paths for `collector.verify` with mocked API responses · Assignee: Tester
 
 
 # Planned Tasks

--- a/design/plan-2025-08-03.md
+++ b/design/plan-2025-08-03.md
@@ -1,0 +1,15 @@
+# Planning Notes - 2025-08-03
+
+## Idea
+We want a simple way for users to verify their API keys and connectivity. We'll design a new `collector.verify` module that calls a subset of data-fetch functions for a few tickers, printing success counts. This acts as a quick smoke test.
+
+## Proposed Command
+- `python -m collector.verify --polygon-key KEY --news-key KEY --symbols AAPL,MSFT,GOOG,TSLA,AMZN`
+- Uses in-memory SQLite via `db.init_db(':memory:')`.
+- Calls `fetch_ohlcv` and `fetch_option_chain` for each symbol.
+- Prints number of bars and options retrieved per symbol.
+- Exits 0 on success or non-zero on API errors.
+
+## Benefits
+- Allows new users to validate their keys without running full pipeline.
+- Keeps API keys off disk by accepting them via CLI and setting env vars during execution.


### PR DESCRIPTION
## Summary
- plan quick API connectivity test command
- update open tasks for DataCollector and Tester
- record planning note for new tasks

## Testing
- `black . --check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880610f3378832491a9a54d17e8c14e