### PR TITLE
[Planner] Add plan for connectivity command and new features

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -4,6 +4,7 @@
 - 2025-08-01 00:10 UTC: Created plan-2025-08-01.md with tasks T21-T25 added to open list.
 - 2025-08-02 00:15 UTC: Reviewed modeling updates; added plan-2025-08-02.md and task T26 for Reviewer.
 - 2025-08-03 00:10 UTC: Planned connectivity test command and wrote plan-2025-08-03.md; added tasks T27 and T28.
+- 2025-08-04 00:20 UTC: Added plan-2025-08-04.md addressing connectivity command and new feature tasks T29-T31.
 - 2025-07-28 00:10 UTC: Planned news integration and playbook generation; see plan-2025-07-28.md and new tasks T16-T17.
 - 2025-07-27 00:45 UTC: Planned feature engineering and modeling tasks; see plan-2025-07-27.md and new tasks T13-T15.
 - 2025-07-23 00:34 UTC: Planned caching, news collection and WebSocket tests; see plan-2025-07-26.md and updated TASKS.md.

--- a/TASKS.md
+++ b/TASKS.md
@@ -9,6 +9,9 @@
 - [T26] Review modeling updates · Acceptance: confirm docs and tests for new features, run `pytest -q` and squash-merge · Assignee: Reviewer
 - [T27] Connectivity test command · Acceptance: `collector.verify` fetches OHLCV and option data for up to 5 symbols using API keys provided via CLI and prints a summary; README documents usage · Assignee: DataCollector
 - [T28] Tests for connectivity command · Acceptance: pytest covers success and failure paths for `collector.verify` with mocked API responses · Assignee: Tester
+- [T29] UOA indicator · Acceptance: `features.pipeline` outputs `uoa` column computed from option volume vs. 30‑day average; tests validate calculation · Assignee: Modeler
+- [T30] IV edge & garch spike features · Acceptance: `features.pipeline` includes `iv_edge` and `garch_spike` columns; tests confirm formulas · Assignee: Modeler
+- [T31] README update for verify command · Acceptance: README section demonstrates `python -m collector.verify` with API keys via CLI · Assignee: Reviewer
 
 
 # Planned Tasks

--- a/design/plan-2025-08-04.md
+++ b/design/plan-2025-08-04.md
@@ -1,0 +1,18 @@
+# Planning Notes - 2025-08-04
+
+## Issue Review
+- Tester reported missing `collector.verify` command preventing test development (T27, T28).
+
+## Decisions
+- Implement simple connectivity check script under `collector/verify.py`.
+- Script should accept API keys via CLI, run small data fetches for up to 5 symbols and print counts.
+- DataCollector will implement; Tester will add mocked tests once available.
+
+## Task Assessment
+- Current open tasks appear actionable. T19 will require IV_edge, UOA and garch_spike features; planning tasks below will provide them.
+
+## New Tasks
+1. **UOA indicator** – Compute unusual options activity per symbol using option volume vs. 30‑day average. Store in `features.csv`. · Assignee: Modeler
+2. **IV edge & garch spike** – Calculate `(iv30 - hv30) / hv30` and detect daily spike when `garch_sigma` > `hv30 * 1.5`. Add columns to feature pipeline. · Assignee: Modeler
+3. **Update README for verify command** – Document new `collector.verify` usage with example invocation. · Assignee: Reviewer
+


### PR DESCRIPTION
## Summary
- plan added to design docs addressing missing connectivity command
- add follow-on tasks for Unusual Options Activity, IV edge, and README updates
- log planning entry in NOTES

## Testing
- `black .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68816ba8716483249eed78266ea885b4