### PR TITLE
Fix metrics loader & REST retries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,12 @@
 # Example environment configuration
 POLYGON_API_KEY=your_polygon_key
+# Unlimited REST access recommended (plan allows ~100 req/sec)
 NEWS_API_KEY=your_news_key
 SLACK_WEBHOOK_URL=
 SYMBOLS=AAPL,MSFT
 ALPACA_API_KEY=
 ALPACA_SECRET_KEY=
-REDIS_URL=redis://localhost:6379/0
+REDIS_URL=redis://redis:6379/0
+# Redis broker for Socket.IO and Celery
 DB_FILE=market_data.db
 REPORTS_DIR=/app/reports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,8 @@ jobs:
         run: black --check . && flake8 && ruff .
       - name: Tests
         run: pytest -q
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: ghcr.io/example/trading-platform:${{ github.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,7 @@ run.log
 reports/scoreboard.csv
 reports/*.html
 market_data_collector.egg-info/
+trading_platform.egg-info/
 models/best_params.json
+models/dummy*
 reports/pnl.csv

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ COPY pyproject.toml ./
 COPY src ./src
 COPY features ./features
 COPY models ./models
-RUN pip install --no-cache-dir -r requirements.txt && \
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt && \
     pip install --no-cache-dir -e . && \
     python -c "import trading_platform.reports.scoreboard"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   web:
     build: .
-    command: gunicorn -w 4 -b 0.0.0.0:5000 'trading_platform.webapp:create_app()'
+    command: gunicorn --worker-class eventlet -w 1 -b 0.0.0.0:5000 'trading_platform.webapp:create_app()'
     ports:
       - "5000:5000"
     volumes:
@@ -9,8 +9,11 @@ services:
       - ./reports:/app/reports
     environment:
       - REPORTS_DIR=/app/reports
+      - REDIS_URL=redis://redis:6379/0
     env_file:
       - .env
+    depends_on:
+      - redis
   scheduler:
     build: .
     command: scheduler
@@ -19,7 +22,18 @@ services:
       - ./reports:/app/reports
     environment:
       - REPORTS_DIR=/app/reports
+      - REDIS_URL=redis://redis:6379/0
     env_file:
       - .env
+    depends_on:
+      - redis
+  redis:
+    image: redis:7
+    command: ["redis-server", "--appendonly", "yes"]
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
 volumes:
   reports:
+  redis-data:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,9 +1,29 @@
 # Changelog
 ## Unreleased
 - Scheduler retries Socket.IO connection with backoff and logs `scheduler_heartbeat`
+- Suppressed noisy Socket.IO "Invalid session" logs and improved demo PnL seeding
 - Added `/api/heartbeat` endpoint for health checks
+- `rate_limited_get` uses exponential backoff on HTTP 429 and raises a clear
+  error on 403 responses
+- Scheduler adds a 2‑minute `run_intraday` job for faster metrics
+- README notes that unlimited REST access allows ~100 req/sec
 - `seed_demo.py` now populates demo news and PnL on first run
 - `/api/metrics` returns Sharpe, Sortino and equity curve
+- `/api/metrics` tolerant of real-world CSVs and returns raw equity records
+- Metrics loader avoids `KeyError` when expected PnL columns are absent
+- Added regression tests covering `profit` column handling in `/api/metrics`
+- Missing API keys return HTTP 503 instead of crashing
+- `/api/metrics` now streams JSON via a Flask ``Response``
+- `seed_demo.py` seeds random PnL data when none found
+- docker-compose runs Gunicorn with a single worker to prevent Socket.IO session errors
+- Gunicorn uses eventlet worker and scheduler skips Socket.IO when Redis is unavailable
+- docker-compose now starts a `redis` service and web/scheduler use `REDIS_URL`
+- Scheduler CLI logs and exits when API keys are missing
+- Socket.IO uses the Redis message queue to prevent worker crashes
+- Redis persists to a local volume with appendonly mode enabled
+- CI workflow builds and pushes Docker images after tests pass
+- Fixed `run_daily` to pass `Config` into `run_pipeline`
+- Global error handler returns JSON and logs exceptions
 - Scoreboard stored under writable reports directory and label shows latest AUC
 - Dashboard displays Sharpe/Sortino metrics and seeded news
 - Packaged `trading_platform.models` stub and hardened DB path for `/api/overview`
@@ -397,4 +417,9 @@
 - Switched Polygon open/close endpoint to v2 and handle 404 with `NoData`
 - Added news table migration and seeder
 - Scheduler defers SocketIO import until runtime
-- Metrics API returns placeholders when PnL missing
+## 2025-07-29
+- Metrics loader handles pnl/profit/total columns and returns equity curve or empty status
+- Missing API keys raise RuntimeError so routes return HTTP 503
+- Redis service added for Socket.IO messaging
+- Added CI workflow to lint, test, and build image
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,8 @@ Install dependencies with the same Python interpreter you use to run the
 collector:
 
 ```bash
-pip install -e .
+# editable install with dev extras for local development
+pip install -e .[dev]
 python3 -m pip install -r requirements.txt
 ```
 
@@ -52,6 +53,9 @@ merged into a single ``Config`` dataclass loaded via
 The ``REPORTS_DIR`` variable controls where generated reports are written. It
 defaults to ``/app/reports`` inside the container and should be writable by
 the app user.
+``REDIS_URL`` is optional but recommended for WebSocket messaging; Docker
+Compose sets it to ``redis://redis:6379/0``.
+Redis persists data under ./redis using appendonly every second.
 
 Logging can be directed to a file and the verbosity adjusted using the
 `--log-file` and `--log-level` arguments, respectively.
@@ -59,8 +63,9 @@ Logging can be directed to a file and the verbosity adjusted using the
 ## Usage
 
 Export your `POLYGON_API_KEY` and set any optional variables described in the
-[Configuration](#configuration) section. Then run the script with optional
-arguments:
+[Configuration](#configuration) section. API routes respond with HTTP `503`
+when required keys are missing, so be sure to provide them in development.
+Then run the script with optional arguments:
 
 ```bash
 python -m trading_platform.market_data_collector \
@@ -117,7 +122,9 @@ The REST API calls include:
 
 The feature pipeline calls these endpoints via helper functions
 `fetch_prev_close`, `fetch_open_close`, `fetch_trades`, `fetch_quotes`, and
-`fetch_snapshot_tickers` to remain compatible with the Starter plan.
+`fetch_snapshot_tickers` to remain compatible with the Starter plan. If your
+account includes unlimited REST, you can schedule the intraday job every
+2 minutes (Polygon asks clients to stay under ~100 requests per second).
 
 ## Reports
 
@@ -132,6 +139,7 @@ Call ``generate_feature_dashboard`` with the features CSV to produce
 `reports/feature_dashboard.html` for interactive exploration of feature
 distributions. Historical results are stored in `reports/scoreboard.csv`.
 Use ``generate_strategy_dashboard`` to write `reports/strategies.html` summarizing POP for available trades.
+The `/api/metrics` endpoint emits an equity curve JSON derived from `reports/pnl.csv`. Columns named `pnl`, `profit`, or `total` are recognised automatically. When no file exists the route responds with `{"status": "empty"}`.
 Risk metrics can be computed from `reports/scoreboard.csv` using the risk report CLI:
 
 ```bash

--- a/features/pipeline.py
+++ b/features/pipeline.py
@@ -50,7 +50,7 @@ def compute_features(df: pd.DataFrame) -> pd.DataFrame:
 def run_pipeline(cfg, symbols: list[str], since: str = "90d") -> str:
     start = (pd.Timestamp.utcnow() - pd.Timedelta(since)).date().isoformat()
     end = pd.Timestamp.utcnow().date().isoformat()
-    out_dir = Path(cfg.reports_dir or REPORTS_DIR)
+    out_dir = Path(getattr(cfg, "reports_dir", REPORTS_DIR) or REPORTS_DIR)
     out_dir.mkdir(parents=True, exist_ok=True)
     all_frames = []
     for sym in symbols:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,11 +22,22 @@ dependencies = [
     "websockets",
     "plotly>=5.22",
     "flask",
-    "flask-socketio",
+    "flask-socketio>=5.3",
     "APScheduler",
     "optuna",
     "python-dotenv",
     "pytest-cov",
+    "redis",
+    "gunicorn",
+    "eventlet",
+]
+
+[project.optional-dependencies]
+dev = [
+    "black",
+    "flake8",
+    "ruff",
+    "pytest",
 ]
 
 [project.scripts]

--- a/requirements.lock
+++ b/requirements.lock
@@ -10,9 +10,11 @@ pytest-asyncio
 websockets
 plotly>=5.22
 flask
-flask-socketio
+flask-socketio>=5.3
 APScheduler
 optuna
 celery
 python-dotenv
 pytest-cov
+redis
+eventlet

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,10 +10,12 @@ pytest-asyncio
 websockets
 plotly>=5.22
 flask
-flask-socketio
+flask-socketio>=5.3
 APScheduler
 optuna
 celery
 python-dotenv
 pytest-cov
 gunicorn
+redis
+eventlet

--- a/scripts/seed_demo.py
+++ b/scripts/seed_demo.py
@@ -4,6 +4,7 @@
 import shutil
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 from sqlalchemy import Column, DateTime, Integer, MetaData, String, Table, create_engine
 
@@ -38,8 +39,14 @@ def seed_pnl() -> None:
     REPORTS_DIR.mkdir(parents=True, exist_ok=True)
     dest = REPORTS_DIR / "pnl.csv"
     demo_pnl = DATA_DIR / "sample_pnl.csv"
-    if not dest.exists() and demo_pnl.exists():
+    if dest.exists():
+        return
+    if demo_pnl.exists():
         shutil.copy(demo_pnl, dest)
+    else:
+        n = 30
+        df = pd.DataFrame({"pnl": np.random.normal(10, 50, n).round(2)})
+        df.to_csv(dest, index=False)
 
 
 def main() -> None:

--- a/src/trading_platform/collector/api.py
+++ b/src/trading_platform/collector/api.py
@@ -12,10 +12,10 @@ from .alerts import AlertAggregator
 
 API_KEY = os.getenv("POLYGON_API_KEY")
 if not API_KEY:
-    raise SystemExit("POLYGON_API_KEY environment variable not set")
+    raise RuntimeError("POLYGON_API_KEY not configured")
 NEWS_API_KEY = os.getenv("NEWS_API_KEY")
 if not NEWS_API_KEY:
-    raise SystemExit("NEWS_API_KEY environment variable not set")
+    raise RuntimeError("NEWS_API_KEY not configured")
 
 WS_URL = "wss://delayed.polygon.io/stocks"
 REALTIME_WS_URL = "wss://socket.polygon.io/stocks"
@@ -40,16 +40,26 @@ def rate_limited_get(url: str, params: Optional[dict] = None) -> dict:
             logging.debug("Cache hit for %s", key)
             return cached[1]
 
-    time.sleep(RATE_LIMIT_SEC)
-    logging.debug("GET %s params=%s", url, params)
-    resp = requests.get(url, params=params)
-    if resp.status_code == 403:
-        raise requests.HTTPError("Forbidden", response=resp)
+    for attempt in range(3):
+        time.sleep(RATE_LIMIT_SEC)
+        logging.debug("GET %s params=%s", url, params)
+        resp = requests.get(url, params=params)
+        if resp.status_code == 403:
+            raise RuntimeError(
+                "Polygon API key rejected – check POLYGON_API_KEY & plan."
+            )
+        if resp.status_code == 429:
+            if attempt < 2:
+                time.sleep(2**attempt)
+                continue
+        resp.raise_for_status()
+        data = resp.json()
+        if CACHE_TTL > 0:
+            _HTTP_CACHE[key] = (now, data)
+        return data
+
     resp.raise_for_status()
-    data = resp.json()
-    if CACHE_TTL > 0:
-        _HTTP_CACHE[key] = (now, data)
-    return data
+    return resp.json()
 
 
 def fetch_prev_close(symbol: str) -> dict:

--- a/src/trading_platform/collector/pnl.py
+++ b/src/trading_platform/collector/pnl.py
@@ -2,50 +2,46 @@
 
 from __future__ import annotations
 
-import importlib
 from pathlib import Path
 
 import pandas as pd
 
-from .. import metrics as m
-from .. import portfolio
-from ..reports import REPORTS_DIR
+REQUIRED_COLS = {"total", "pnl", "profit"}
 
 
-class NoData(Exception):
-    pass
+def update_pnl(path: Path) -> pd.DataFrame | None:
+    """Return equity curve DataFrame from ``path``.
 
+    Parameters
+    ----------
+    path : Path
+        CSV file containing PnL data. Column names are matched
+        case-insensitively against ``REQUIRED_COLS``.
 
-def update_pnl(since: str | None = None, path: Path | None = None) -> pd.DataFrame:
-    use_portfolio = path is None
-    path = Path(path or REPORTS_DIR / "pnl.csv")
+    Returns
+    -------
+    pandas.DataFrame | None
+        ``None`` if the file is missing or does not contain a recognised PnL
+        column. Otherwise a DataFrame with ``equity`` and the PnL column and
+        ``date`` if present.
+    """
+
     if not path.exists():
-        raise NoData("pnl missing")
-    if use_portfolio:
-        df = portfolio.load_pnl(str(path))
-    else:
-        df = pd.read_csv(path)
+        return None
+
+    df = pd.read_csv(path)
     if df.empty:
-        raise NoData("pnl empty")
-    df["date"] = pd.to_datetime(df["date"])
-    if since and since.endswith("d"):
-        try:
-            n = int(since[:-1])
-            cutoff = pd.Timestamp.utcnow().normalize() - pd.Timedelta(days=n)
-            cutoff = cutoff.tz_localize(None)
-            df = df[df["date"] >= cutoff]
-        except ValueError:
-            pass
-    df = df.sort_values("date")
-    equity = df["total"].cumsum()
-    daily = equity.pct_change().fillna(0)
-    sharpe = m.sharpe_ratio(daily)
-    sortino = m.sortino_ratio(daily)
-    out = pd.DataFrame(
-        {"date": df["date"].dt.date.astype(str), "equity": equity, "daily_r": daily}
-    )
-    out["sharpe"] = sharpe
-    out["sortino"] = sortino
-    out.to_csv(path, index=False)
-    importlib.reload(portfolio)  # reset any monkeypatched functions
-    return out
+        return None
+
+    df.columns = df.columns.str.strip().str.lower()
+    col = next((c for c in REQUIRED_COLS if c in df.columns), None)
+    if col is None:
+        return None
+
+    df["equity"] = df[col].cumsum()
+
+    cols = []
+    if "date" in df.columns:
+        cols.append("date")
+    cols.extend(["equity", col])
+    return df[cols]

--- a/src/trading_platform/run_daily.py
+++ b/src/trading_platform/run_daily.py
@@ -52,7 +52,7 @@ def run(config: Config) -> str:
             api.fetch_news(conn, sym, aggregator=agg)
 
     try:
-        feat_csv = run_pipeline(conn, config.symbols.split(",")[0])
+        feat_csv = run_pipeline(config, [config.symbols.split(",")[0]])
         res = train_model(feat_csv, "models", symbol=config.symbols.split(",")[0])
         if not res.model_path:
             raise RuntimeError("drift guard triggered")
@@ -120,6 +120,14 @@ def run(config: Config) -> str:
     if socketio:
         socketio.emit("dashboard-refresh", {})
     return pb_path
+
+
+def run_intraday(config: Config) -> None:
+    """Lightweight intraday refresh pipeline."""
+    try:
+        run(config)
+    except Exception as exc:  # pragma: no cover - just log
+        logging.error("intraday job failed: %s", exc)
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/src/trading_platform/scheduler.py
+++ b/src/trading_platform/scheduler.py
@@ -28,10 +28,21 @@ def healthz():
 def _connect_socketio() -> None:
     """Initialise Socket.IO with retries."""
     global socketio
+    redis_url = os.getenv("REDIS_URL")
+    if redis_url:
+        try:  # pragma: no cover - optional dependency
+            import redis  # noqa:F401
+        except Exception:  # pragma: no cover - optional dependency
+            _log.warning("Redis package not installed; Socket.IO disabled")
+            return
     delay = 1
     while True:
         try:
-            socketio = SocketIO(message_queue=os.getenv("REDIS_URL"))
+            socketio = SocketIO(
+                message_queue=redis_url,
+                async_mode="eventlet",
+                ping_timeout=20,
+            )
             if socketio.server:
                 _log.info("Socket.IO connected")
                 break
@@ -74,12 +85,23 @@ def start(config: Config, interval: int = 86400, run_func=None) -> BackgroundSch
     """
 
     if run_func is None:
-        from .run_daily import run as run_daily
+        try:
+            from .run_daily import run as run_daily
+        except RuntimeError as exc:
+            raise RuntimeError(f"Cannot start scheduler: {exc}") from exc
 
         run_func = run_daily
 
     sched = BackgroundScheduler()
     sched.add_job(run_func, "interval", seconds=interval, args=(config,))
+    try:
+        from .run_daily import run_intraday
+
+        sched.add_job(
+            run_intraday, "interval", minutes=2, max_instances=1, args=(config,)
+        )
+    except Exception:  # pragma: no cover - optional
+        _log.warning("run_intraday not available")
     sched.add_job(_log_heartbeat, "interval", seconds=30)
     sched.start()
 
@@ -92,7 +114,11 @@ def main(argv: list[str] | None = None) -> None:
     """CLI entry point for the scheduler."""
     load_dotenv()
     cfg = load_config(argv)
-    start(cfg)
+    try:
+        start(cfg)
+    except RuntimeError as exc:
+        _log.error(exc)
+        return
     Thread(target=health_app.run, kwargs={"host": "0.0.0.0", "port": 8001}).start()
     try:
         while True:

--- a/tests/test_api_metrics.py
+++ b/tests/test_api_metrics.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 from trading_platform.webapp import create_app
@@ -7,7 +8,9 @@ def test_api_metrics_empty(tmp_path):
     env = tmp_path / ".env"
     env.write_text("POLYGON_API_KEY=x\n")
     app = create_app(env_path=env)
-    app.static_folder = str(tmp_path)
+    csv = Path(os.environ["REPORTS_DIR"]) / "pnl.csv"
+    if csv.exists():
+        csv.unlink()
     client = app.test_client()
     resp = client.get("/api/metrics")
     assert resp.json.get("status") == "empty"
@@ -17,19 +20,35 @@ def test_api_metrics_values(tmp_path):
     env = tmp_path / ".env"
     env.write_text("POLYGON_API_KEY=x\n")
     app = create_app(env_path=env)
-    app.static_folder = str(tmp_path)
-    csv = Path(app.static_folder) / "pnl.csv"
-    csv.write_text("date,total\n2025-01-01,1\n2025-01-02,2\n")
+    csv = Path(os.environ["REPORTS_DIR"]) / "pnl.csv"
+    csv.write_text("pnl\n1\n2\n-1\n")
     client = app.test_client()
     resp = client.get("/api/metrics")
-    assert resp.json["status"] == "ok"
+    assert resp.status_code == 200
+    assert len(resp.get_json()) == 3
+
+
+def test_api_metrics_profit_column(tmp_path):
+    env = tmp_path / ".env"
+    env.write_text("POLYGON_API_KEY=x\n")
+    app = create_app(env_path=env)
+    csv = Path(os.environ["REPORTS_DIR"]) / "pnl.csv"
+    csv.write_text("profit\n5\n-2\n7\n")
+    client = app.test_client()
+    resp = client.get("/api/metrics")
+    data = resp.get_json()
+    assert resp.status_code == 200
+    assert data[0]["equity"] == 5
+    assert data[-1]["equity"] == 10
 
 
 def test_api_metrics_missing_file(tmp_path):
     env = tmp_path / ".env"
     env.write_text("POLYGON_API_KEY=x\n")
     app = create_app(env_path=env)
-    app.static_folder = str(tmp_path)
+    csv = Path(os.environ["REPORTS_DIR"]) / "pnl.csv"
+    if csv.exists():
+        csv.unlink()
     client = app.test_client()
     resp = client.get("/api/metrics")
     assert resp.json == {"status": "empty"}

--- a/tests/test_equity_api.py
+++ b/tests/test_equity_api.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import pandas as pd
@@ -9,14 +10,11 @@ def test_api_equity_last(tmp_path):
     env = tmp_path / ".env"
     env.write_text("POLYGON_API_KEY=x\n")
     app = create_app(env_path=env)
-    app.static_folder = str(tmp_path)
-    csv = Path(app.static_folder) / "pnl.csv"
+    csv = Path(os.environ["REPORTS_DIR"]) / "pnl.csv"
     csv.parent.mkdir(parents=True, exist_ok=True)
-    df = pd.DataFrame({"date": ["2025-01-01", "2025-01-02"], "total": [1, 2]})
+    csv.unlink(missing_ok=True)
+    df = pd.DataFrame({"date": ["2025-01-01", "2025-01-02"], "pnl": [1, 2]})
     df.to_csv(csv, index=False)
-    import trading_platform.portfolio as pf
-
-    pf.load_pnl = lambda path=pf.PNL_FILE: pd.read_csv(csv)
     client = app.test_client()
     resp = client.get("/api/metrics/equity?last=400d")
     assert resp.status_code == 200
@@ -27,13 +25,10 @@ def test_api_equity_empty(tmp_path):
     env = tmp_path / ".env"
     env.write_text("POLYGON_API_KEY=x\n")
     app = create_app(env_path=env)
-    app.static_folder = str(tmp_path)
-    csv = Path(app.static_folder) / "pnl.csv"
+    csv = Path(os.environ["REPORTS_DIR"]) / "pnl.csv"
     csv.parent.mkdir(parents=True, exist_ok=True)
-    csv.write_text("date,total\n")
-    import trading_platform.portfolio as pf
-
-    pf.load_pnl = lambda path=pf.PNL_FILE: pd.read_csv(csv)
+    csv.unlink(missing_ok=True)
+    csv.write_text("date,pnl\n")
     client = app.test_client()
     resp = client.get("/api/metrics/equity")
     assert resp.status_code == 200

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -8,6 +8,8 @@ def test_load_pipeline_callable():
 
 
 def test_run_pipeline(monkeypatch, tmp_path):
+    monkeypatch.setenv("POLYGON_API_KEY", "x")
+    monkeypatch.setenv("NEWS_API_KEY", "y")
     from features import pipeline
 
     def fake_get(url, params=None):

--- a/tests/test_metrics_api.py
+++ b/tests/test_metrics_api.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 from trading_platform.webapp import create_app
@@ -7,7 +8,9 @@ def test_metrics_empty(tmp_path):
     env = tmp_path / ".env"
     env.write_text("POLYGON_API_KEY=x\n")
     app = create_app(env_path=env)
-    app.static_folder = str(tmp_path)
+    csv = Path(os.environ["REPORTS_DIR"]) / "pnl.csv"
+    if csv.exists():
+        csv.unlink()
     client = app.test_client()
     resp = client.get("/api/metrics")
     assert resp.json == {"status": "empty"}
@@ -17,10 +20,9 @@ def test_metrics_populated(tmp_path):
     env = tmp_path / ".env"
     env.write_text("POLYGON_API_KEY=x\n")
     app = create_app(env_path=env)
-    app.static_folder = str(tmp_path)
-    csv = Path(app.static_folder) / "pnl.csv"
-    csv.write_text("date,total\n2025-01-01,1\n2025-01-02,2\n")
+    csv = Path(os.environ["REPORTS_DIR"]) / "pnl.csv"
+    csv.write_text("pnl\n1\n2\n-1\n")
     client = app.test_client()
     resp = client.get("/api/metrics")
-    assert resp.json["status"] == "ok"
-    assert "equity" in resp.json
+    assert resp.status_code == 200
+    assert len(resp.get_json()) == 3

--- a/tests/test_run_daily.py
+++ b/tests/test_run_daily.py
@@ -33,7 +33,12 @@ def test_run_daily_notify_failure(monkeypatch, tmp_path):
     monkeypatch.setattr(run_daily.api, "fetch_option_chain", lambda *a, **k: None)
     monkeypatch.setattr(run_daily.api, "fetch_news", lambda *a, **k: None)
 
-    monkeypatch.setattr(run_daily, "run_pipeline", lambda *a, **k: "features.csv")
+    def fake_run_pipeline(cfg, symbols):
+        assert isinstance(cfg, Config)
+        assert symbols == ["AAPL"]
+        return "features.csv"
+
+    monkeypatch.setattr(run_daily, "run_pipeline", fake_run_pipeline)
 
     def fail_train(csv, model_dir="models", symbol="AAPL"):
         raise RuntimeError("boom")
@@ -74,7 +79,9 @@ def test_run_daily_success(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr(run_daily.api, "fetch_option_chain", fake_fetch_option_chain)
     monkeypatch.setattr(run_daily.api, "fetch_news", fake_fetch_news)
 
-    def fake_run_pipeline(conn, sym, out_dir="features"):
+    def fake_run_pipeline(cfg, symbols, since="90d"):
+        assert isinstance(cfg, Config)
+        assert symbols == ["AAPL"]
         path = tmp_path / "feat.csv"
         path.write_text("t,close\n1,1")
         return str(path)

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -109,13 +109,12 @@ def test_metrics_empty_no_rows(tmp_path):
     env = tmp_path / ".env"
     env.write_text("POLYGON_API_KEY=abc\n")
     app = create_app(env_path=env)
-    app.static_folder = str(tmp_path)
-    csv = Path(app.static_folder) / "pnl.csv"
+    csv = Path(os.environ["REPORTS_DIR"]) / "pnl.csv"
     csv.write_text("total\n")
     client = app.test_client()
     resp = client.get("/api/metrics")
     assert resp.status_code == 200
-    assert resp.json.get("status") in {"empty", "ok"}
+    assert resp.json.get("status") == "empty"
 
 
 def test_api_latest_features_and_options(tmp_path):

--- a/tests/web/test_api_routes.py
+++ b/tests/web/test_api_routes.py
@@ -1,3 +1,4 @@
+import os
 import sqlite3
 from pathlib import Path
 
@@ -8,7 +9,8 @@ def test_metrics_empty_when_auc_missing(tmp_path):
     env = tmp_path / ".env"
     env.write_text("POLYGON_API_KEY=abc\n")
     app = create_app(env_path=env)
-    csv = Path(app.static_folder) / "pnl.csv"
+    csv = Path(os.environ["REPORTS_DIR"]) / "pnl.csv"
+    csv.unlink(missing_ok=True)
     csv.write_text("total\n")
     client = app.test_client()
     resp = client.get("/api/metrics")


### PR DESCRIPTION
## Summary
- tolerate varying PnL columns and expose equity JSON
- return HTTP 503 for missing API keys
- retry Polygon REST calls on 429 and raise error on 403
- schedule 2‑minute intraday job
- document unlimited REST usage

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6886f8df98d083249a9a98bf52e5fe36