### PR TITLE
Fix timezone issue in scheduler Docker build

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@
 - docker-compose runs Gunicorn with a single worker to prevent Socket.IO session errors
 - Gunicorn uses eventlet worker and scheduler skips Socket.IO when Redis is unavailable
 - docker-compose now starts a `redis` service and web/scheduler use `REDIS_URL`
+- Added `tzdata` dependency to fix scheduler timezone errors in Docker
 - Scheduler CLI logs and exits when API keys are missing
 - Socket.IO uses the Redis message queue to prevent worker crashes
 - Redis persists to a local volume with appendonly mode enabled

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ redis
 prometheus-client
 eventlet
 pandas-market-calendars
+tzdata


### PR DESCRIPTION
## Summary
- add `tzdata` dependency for timezone support in Docker
- document the fix in CHANGELOG

## Testing
- `black .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a73c7a4848324bd33c0d6f0abc6d8